### PR TITLE
GNB 컨텐츠 i18n 적용

### DIFF
--- a/frontend/public/components/hypercloud/modals/notice-expiration-modal.jsx
+++ b/frontend/public/components/hypercloud/modals/notice-expiration-modal.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Translation } from 'react-i18next';
 import { createModalLauncher, ModalBody, ModalTitle } from '../../factory';
 import { CustomModalSubmitFooter } from './modal';
 
@@ -45,19 +46,27 @@ class NoticeExpirationModal extends Component {
 
   render() {
     return (
-      // TODO: i18n
-      <form name="form" className="modal-content">
-        <ModalTitle>세션 만료 알림</ModalTitle>
-        <ModalBody>
-          <div className="form-group">
-            <label className="control-label">{Math.floor(this.state.time)}초 뒤에 자동으로 로그아웃 될 예정입니다.</label>
-            <label className="control-label">로그인 상태를 유지하시려면 연장 버튼을 클릭해주세요.</label>
-          </div>
-        </ModalBody>
-        <CustomModalSubmitFooter inProgress={false} leftBtnText="세션 연장" rightBtnText="로그아웃" onClickLeft={this._extend} onClickRight={this._logout} />
-      </form>
+      <Translation>
+        {t => (
+          <>
+            <form name="form" className="modal-content">
+              <ModalTitle>{t('COMMON:MSG_GNB_SESSION_9')}</ModalTitle>
+              <ModalBody>
+                <div className="form-group">
+                  <label className="control-label">
+                    {t('COMMON:MSG_GNB_SESSION_10', {
+                      count: Math.floor(this.state.time),
+                    })}
+                  </label>
+                </div>
+              </ModalBody>
+              <CustomModalSubmitFooter inProgress={false} leftBtnText={t('COMMON:MSG_GNB_SESSION_9')} rightBtnText={t('COMMON:MSG_GNB_ACCOUNT_2')} onClickLeft={this._extend} onClickRight={this._logout} />
+            </form>
+          </>
+        )}
+      </Translation>
     );
   }
 }
 
-export const NoticeExpirationModal_ = createModalLauncher(props => <NoticeExpirationModal path="status" title="세션 만료 알림" {...props} />);
+export const NoticeExpirationModal_ = createModalLauncher(props => <Translation>{t => <NoticeExpirationModal path="status" title={t('COMMON:MSG_GNB_SESSION_9')} {...props} />}</Translation>);

--- a/frontend/public/components/hypercloud/utils/langs/en.json
+++ b/frontend/public/components/hypercloud/utils/langs/en.json
@@ -103,7 +103,7 @@
     "MSG_GNB_SESSION_7": "Allows numbers only.",
     "MSG_GNB_SESSION_8": "Enter the session expiration time.",
     "MSG_GNB_SESSION_9": "Extend Session Timeout",
-    "MSG_GNB_SESSION_10": "You will be automatically logged out after {0} seconds.\nClick the Extend button to stay logged in.",
+    "MSG_GNB_SESSION_10": "You will be automatically logged out after {{count}} seconds.\nClick the Extend button to stay logged in.",
     "MSG_GNB_NOTIFICATIONS_1": "Notifications",
     "MSG_GNB_IMPORTYAML_1": "Import YAML",
     "MSG_GNB_MORE_1": "Documentation",

--- a/frontend/public/components/hypercloud/utils/langs/ko.json
+++ b/frontend/public/components/hypercloud/utils/langs/ko.json
@@ -103,7 +103,7 @@
     "MSG_GNB_SESSION_7": "숫자만 입력할 수 있습니다.",
     "MSG_GNB_SESSION_8": "세션 만료 시간을 입력해 주세요.",
     "MSG_GNB_SESSION_9": "세션 연장",
-    "MSG_GNB_SESSION_10": "{0}초 뒤에 자동으로 로그아웃 될 예정입니다.\n로그인 상태를 유지하시려면 연장 버튼을 클릭해주세요.",
+    "MSG_GNB_SESSION_10": "{{count}}초 뒤에 자동으로 로그아웃 될 예정입니다.\n로그인 상태를 유지하시려면 연장 버튼을 클릭해주세요.",
     "MSG_GNB_NOTIFICATIONS_1": "경고",
     "MSG_GNB_IMPORTYAML_1": "",
     "MSG_GNB_MORE_1": "매뉴얼",

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -19,7 +19,7 @@ import * as redhatLogoImg from '../imgs/logos/redhat.svg';
 import { withKeycloak } from '@react-keycloak/web';
 import { ExpTimer } from './hypercloud/exp-timer';
 
-import { Translation } from 'react-i18next';
+import { withTranslation } from 'react-i18next';
 import i18n from 'i18next';
 
 const SystemStatusButton = ({ statuspageData, className }) =>
@@ -326,7 +326,7 @@ class MastheadToolbarContents_ extends React.Component {
   }
 
   _renderMenu(mobile) {
-    const { flags, consoleLinks, keycloak } = this.props;
+    const { flags, consoleLinks, keycloak, t } = this.props;
     const username = keycloak.idTokenParsed.email;
     const { isUserDropdownOpen, isKebabDropdownOpen } = this.state;
     const additionalUserActions = this._getAdditionalActions(this._getAdditionalLinks(consoleLinks, 'UserMenu'));
@@ -348,15 +348,13 @@ class MastheadToolbarContents_ extends React.Component {
     };
 
     userActions.push({
-      // TODO: i18n
-      label: 'Manage Account',
+      label: t('COMMON:MSG_GNB_ACCOUNT_1'),
       callback: openAccountConsole,
       component: 'button',
     });
 
     userActions.push({
-      // TODO: i18n
-      label: 'Log out',
+      label: t('COMMON:MSG_GNB_ACCOUNT_2'),
       callback: logout,
       component: 'button',
     });
@@ -405,7 +403,7 @@ class MastheadToolbarContents_ extends React.Component {
     return <ApplicationLauncher aria-label="User menu" data-test="user-dropdown" className="co-app-launcher co-user-menu" onSelect={this._onUserDropdownSelect} onToggle={this._onUserDropdownToggle} isOpen={isUserDropdownOpen} items={this._renderApplicationItems(actions)} position="right" toggleIcon={userToggle} isGrouped />;
   }
   _renderLanguageMenu(mobile) {
-    const { flags, consoleLinks, keycloak } = this.props;
+    const { flags, consoleLinks, keycloak, t } = this.props;
     const { isLanguageDropdownOpen } = this.state;
 
     const actions = [];
@@ -423,13 +421,13 @@ class MastheadToolbarContents_ extends React.Component {
     };
 
     i18nActions.push({
-      label: 'EN-US',
+      label: t('COMMON:MSG_GNB_LANGUAGE_2'),
       callback: enChange,
       component: 'button',
     });
 
     i18nActions.push({
-      label: '한국어',
+      label: t('COMMON:MSG_GNB_LANGUAGE_1'),
       callback: koChange,
       component: 'button',
     });
@@ -455,15 +453,11 @@ class MastheadToolbarContents_ extends React.Component {
     }
 
     const languageToggle = (
-      <Translation>
-        {t => (
-          <span className="pf-c-dropdown__toggle">
-            {/* i18n 키값 요청 후 적용하기 */}
-            <span className="co-username">Language</span>
-            <CaretDownIcon className="pf-c-dropdown__toggle-icon" />
-          </span>
-        )}
-      </Translation>
+      <span className="pf-c-dropdown__toggle">
+        {/* i18n 키값 요청 후 적용하기 - 현재 선택된 언어를 표현하는 키값 - 한국어, 영어 */}
+        <span className="co-username">Language</span>
+        <CaretDownIcon className="pf-c-dropdown__toggle-icon" />
+      </span>
     );
 
     return <ApplicationLauncher aria-label="Language menu" data-test="language-dropdown" className="co-app-launcher co-user-menu" onSelect={this._onLanguageDropdownSelect} onToggle={this._onLanguageDropdownToggle} isOpen={isLanguageDropdownOpen} items={this._renderApplicationItems(actions)} position="right" toggleIcon={languageToggle} isGrouped />;
@@ -495,7 +489,7 @@ class MastheadToolbarContents_ extends React.Component {
 
   render() {
     const { isApplicationLauncherDropdownOpen, isHelpDropdownOpen, showAboutModal, statuspageData } = this.state;
-    const { consoleLinks, drawerToggle, notificationsRead, canAccessNS, keycloak } = this.props;
+    const { consoleLinks, drawerToggle, notificationsRead, canAccessNS, keycloak, t } = this.props;
     const launchActions = this._launchActions();
     const alertAccess = canAccessNS && !!window.SERVER_FLAGS.prometheusBaseURL;
     return (
@@ -522,7 +516,7 @@ class MastheadToolbarContents_ extends React.Component {
                   this._tokenRefresh();
                 }}
               >
-                Extend
+                {t('COMMON:MSG_GNB_SESSION_1')}
               </Button>
             </ToolbarItem>
             {/* desktop -- (system status button) */}
@@ -588,7 +582,7 @@ const mastheadToolbarStateToProps = state => ({
 
 const MastheadToolbarContents = connect(mastheadToolbarStateToProps, {
   drawerToggle: UIActions.notificationDrawerToggleExpanded,
-})(connectToFlags(FLAGS.AUTH_ENABLED, FLAGS.CONSOLE_CLI_DOWNLOAD, FLAGS.OPENSHIFT)(withKeycloak(MastheadToolbarContents_)));
+})(connectToFlags(FLAGS.AUTH_ENABLED, FLAGS.CONSOLE_CLI_DOWNLOAD, FLAGS.OPENSHIFT)(withKeycloak(withTranslation()(MastheadToolbarContents_))));
 
 export const MastheadToolbar = connectToFlags(FLAGS.CLUSTER_VERSION)(({ flags }) => {
   const resources = flags[FLAGS.CLUSTER_VERSION]


### PR DESCRIPTION
#### What: GNB i18n 적용

#### Why: i18n 적용이 필요해서

#### How: react-i18next 라이브러리 사용
- masthead-toolbar
  - MastheadToolbarContents_ 컴포넌트가 클래스형 컴포넌트이며, 중간중간 함수 내 로직에 String 을 넣어주어야 하는 부분이 있어 withTranslation 을 사용했습니다. 좋은 아이디어 있으면 공유 부탁드립니다. 
- 세션 팝업
  - 팀 내 i18n 적용 가이드대로 Translation 태그 사용하였습니다.
