### PR TITLE
[feat] 리스트, 디테일 페이지 추가

### DIFF
--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -151,6 +151,11 @@ const AppContents_: React.FC<AppContentsProps> = ({ activePerspective, flags }) 
           <Route path="/search/all-namespaces" exact component={NamespaceFromURL(SearchPage)} />
           <Route path="/search/ns/:ns" exact component={NamespaceFromURL(SearchPage)} />
           <Route path="/search" exact component={NamespaceRedirect} />
+
+          <LazyRoute path="/kiali/all-namespaces" exact loader={() => import('./hypercloud/kiali' /* webpackChunkName: "kiali" */).then(m => NamespaceFromURL(m.KialiPage))} />
+          <LazyRoute path="/kiali/ns/:ns" exact loader={() => import('./hypercloud/kiali' /* webpackChunkName: "kiali" */).then(m => NamespaceFromURL(m.KialiPage))} />
+          <Route path="/kiali" exact component={NamespaceRedirect} />
+
           <LazyRoute path="/k8s/all-namespaces/import" exact loader={() => import('./import-yaml' /* webpackChunkName: "import-yaml" */).then(m => NamespaceFromURL(m.ImportYamlPage))} />
           <LazyRoute path="/k8s/ns/:ns/import/" exact loader={() => import('./import-yaml' /* webpackChunkName: "import-yaml" */).then(m => NamespaceFromURL(m.ImportYamlPage))} />
           {

--- a/frontend/public/components/hypercloud/authentication-policy.tsx
+++ b/frontend/public/components/hypercloud/authentication-policy.tsx
@@ -1,0 +1,99 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { sortable } from '@patternfly/react-table';
+
+import { K8sResourceKind } from '../../module/k8s';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from '../factory';
+import { Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
+import { Status } from '@console/shared';
+import { AuthorizationPolicyModel } from '../../models';
+
+export const menuActions: KebabAction[] = [...Kebab.getExtensionsActionsForKind(AuthorizationPolicyModel), ...Kebab.factory.common];
+
+const kind = AuthorizationPolicyModel.kind;
+
+const tableColumnClasses = ['', '', classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'), Kebab.columnClass];
+
+const AuthorizationPolicyTableHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortFunc: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Created',
+      sortField: 'metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[3] },
+    },
+  ];
+};
+AuthorizationPolicyTableHeader.displayName = 'AuthorizationPolicyTableHeader';
+
+const AuthorizationPolicyTableRow: RowFunction<K8sResourceKind> = ({ obj: authorizationpolicy, index, key, style }) => {
+  return (
+    <TableRow id={authorizationpolicy.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink kind={kind} name={authorizationpolicy.metadata.name} namespace={authorizationpolicy.metadata.namespace} title={authorizationpolicy.metadata.uid} />
+      </TableData>
+      <TableData className={tableColumnClasses[1]}>
+        <Status status={authorizationpolicy.metadata.namespace} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
+        <Timestamp timestamp={authorizationpolicy.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <ResourceKebab actions={menuActions} kind={kind} resource={authorizationpolicy} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+const AuthorizationPolicyDetails: React.FC<AuthorizationPolicyDetailsProps> = ({ obj: authorizationpolicy }) => (
+  <>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Authorization Policy Details" />
+      <div className="row">
+        <div className="col-lg-6">
+          <ResourceSummary resource={authorizationpolicy} />
+        </div>
+      </div>
+    </div>
+    <div className="co-m-pane__body">
+    </div>
+  </>
+);
+
+const { details, editYaml } = navFactory;
+export const AuthorizationPolicies: React.FC = props => <Table {...props} aria-label="Authorization Policies" Header={AuthorizationPolicyTableHeader} Row={AuthorizationPolicyTableRow} virtualize />;
+
+export const AuthorizationPoliciesPage: React.FC<AuthorizationPoliciesPageProps> = props => <ListPage canCreate={true} ListComponent={AuthorizationPolicies} kind={kind} {...props} />;
+
+export const AuthorizationPoliciesDetailsPage: React.FC<AuthorizationPoliciesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(AuthorizationPolicyDetails)), editYaml()]} />;
+
+type AuthorizationPolicyDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type AuthorizationPoliciesPageProps = {
+  showTitle?: boolean;
+  namespace?: string;
+  selector?: any;
+};
+
+type AuthorizationPoliciesDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/hypercloud/data-volume.tsx
+++ b/frontend/public/components/hypercloud/data-volume.tsx
@@ -1,0 +1,99 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { sortable } from '@patternfly/react-table';
+
+import { K8sResourceKind } from '../../module/k8s';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from '../factory';
+import { Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
+import { Status } from '@console/shared';
+import { DataVolumeModel } from '../../models';
+
+export const menuActions: KebabAction[] = [...Kebab.getExtensionsActionsForKind(DataVolumeModel), ...Kebab.factory.common];
+
+const kind = DataVolumeModel.kind;
+
+const tableColumnClasses = ['', '', classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'), Kebab.columnClass];
+
+const DataVolumeTableHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortFunc: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Created',
+      sortField: 'metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[3] },
+    },
+  ];
+};
+DataVolumeTableHeader.displayName = 'DataVolumeTableHeader';
+
+const DataVolumeTableRow: RowFunction<K8sResourceKind> = ({ obj: datavolume, index, key, style }) => {
+  return (
+    <TableRow id={datavolume.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink kind={kind} name={datavolume.metadata.name} namespace={datavolume.metadata.namespace} title={datavolume.metadata.uid} />
+      </TableData>
+      <TableData className={tableColumnClasses[1]}>
+        <Status status={datavolume.metadata.namespace} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
+        <Timestamp timestamp={datavolume.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <ResourceKebab actions={menuActions} kind={kind} resource={datavolume} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+const DataVolumeDetails: React.FC<DataVolumeDetailsProps> = ({ obj: datavolume }) => (
+  <>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Data Volume Details" />
+      <div className="row">
+        <div className="col-lg-6">
+          <ResourceSummary resource={datavolume} />
+        </div>
+      </div>
+    </div>
+    <div className="co-m-pane__body">
+    </div>
+  </>
+);
+
+const { details, editYaml } = navFactory;
+export const DataVolumes: React.FC = props => <Table {...props} aria-label="Data Volumes" Header={DataVolumeTableHeader} Row={DataVolumeTableRow} virtualize />;
+
+export const DataVolumesPage: React.FC<DataVolumesPageProps> = props => <ListPage canCreate={true} ListComponent={DataVolumes} kind={kind} {...props} />;
+
+export const DataVolumesDetailsPage: React.FC<DataVolumesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(DataVolumeDetails)), editYaml()]} />;
+
+type DataVolumeDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type DataVolumesPageProps = {
+  showTitle?: boolean;
+  namespace?: string;
+  selector?: any;
+};
+
+type DataVolumesDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/hypercloud/destination-rule.tsx
+++ b/frontend/public/components/hypercloud/destination-rule.tsx
@@ -1,0 +1,108 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { sortable } from '@patternfly/react-table';
+
+import { K8sResourceKind } from '../../module/k8s';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from '../factory';
+import { Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
+import { Status } from '@console/shared';
+import { DestinationRuleModel } from '../../models';
+
+export const menuActions: KebabAction[] = [...Kebab.getExtensionsActionsForKind(DestinationRuleModel), ...Kebab.factory.common];
+
+const kind = DestinationRuleModel.kind;
+
+const tableColumnClasses = ['', '', classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'), classNames('pf-m-hidden', 'pf-m-visible-on-lg'), Kebab.columnClass];
+
+const DestinationRuleTableHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortFunc: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Host',
+      sortField: 'spec.hosts',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: 'Created',
+      sortField: 'metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[3] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[4] },
+    },
+  ];
+};
+DestinationRuleTableHeader.displayName = 'DestinationRuleTableHeader';
+
+const DestinationRuleTableRow: RowFunction<K8sResourceKind> = ({ obj: destinationrule, index, key, style }) => {
+  return (
+    <TableRow id={destinationrule.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink kind={kind} name={destinationrule.metadata.name} namespace={destinationrule.metadata.namespace} title={destinationrule.metadata.uid} />
+      </TableData>
+      <TableData className={tableColumnClasses[1]}>
+        <Status status={destinationrule.metadata.namespace} />
+      </TableData>
+      <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
+        {destinationrule.spec.host}
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <Timestamp timestamp={destinationrule.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={tableColumnClasses[4]}>
+        <ResourceKebab actions={menuActions} kind={kind} resource={destinationrule} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+const DestinationRuleDetails: React.FC<DestinationRuleDetailsProps> = ({ obj: destinationrule }) => (
+  <>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Destination Rule Details" />
+      <div className="row">
+        <div className="col-lg-6">
+          <ResourceSummary resource={destinationrule} />
+        </div>
+      </div>
+    </div>
+    <div className="co-m-pane__body">
+    </div>
+  </>
+);
+
+const { details, editYaml } = navFactory;
+export const DestinationRules: React.FC = props => <Table {...props} aria-label="Destination Rules" Header={DestinationRuleTableHeader} Row={DestinationRuleTableRow} virtualize />;
+
+export const DestinationRulesPage: React.FC<DestinationRulesPageProps> = props => <ListPage canCreate={true} ListComponent={DestinationRules} kind={kind} {...props} />;
+
+export const DestinationRulesDetailsPage: React.FC<DestinationRulesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(DestinationRuleDetails)), editYaml()]} />;
+
+type DestinationRuleDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type DestinationRulesPageProps = {
+  showTitle?: boolean;
+  namespace?: string;
+  selector?: any;
+};
+
+type DestinationRulesDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/hypercloud/envoy-filter.tsx
+++ b/frontend/public/components/hypercloud/envoy-filter.tsx
@@ -1,0 +1,99 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { sortable } from '@patternfly/react-table';
+
+import { K8sResourceKind } from '../../module/k8s';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from '../factory';
+import { Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
+import { Status } from '@console/shared';
+import { EnvoyFilterModel } from '../../models';
+
+export const menuActions: KebabAction[] = [...Kebab.getExtensionsActionsForKind(EnvoyFilterModel), ...Kebab.factory.common];
+
+const kind = EnvoyFilterModel.kind;
+
+const tableColumnClasses = ['', '', classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'), Kebab.columnClass];
+
+const EnvoyFilterTableHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortFunc: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Created',
+      sortField: 'metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[3] },
+    },
+  ];
+};
+EnvoyFilterTableHeader.displayName = 'EnvoyFilterTableHeader';
+
+const EnvoyFilterTableRow: RowFunction<K8sResourceKind> = ({ obj: envoyfilter, index, key, style }) => {
+  return (
+    <TableRow id={envoyfilter.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink kind={kind} name={envoyfilter.metadata.name} namespace={envoyfilter.metadata.namespace} title={envoyfilter.metadata.uid} />
+      </TableData>
+      <TableData className={tableColumnClasses[1]}>
+        <Status status={envoyfilter.metadata.namespace} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
+        <Timestamp timestamp={envoyfilter.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <ResourceKebab actions={menuActions} kind={kind} resource={envoyfilter} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+const EnvoyFilterDetails: React.FC<EnvoyFilterDetailsProps> = ({ obj: envoyfilter }) => (
+  <>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Envoy Filter Details" />
+      <div className="row">
+        <div className="col-lg-6">
+          <ResourceSummary resource={envoyfilter} />
+        </div>
+      </div>
+    </div>
+    <div className="co-m-pane__body">
+    </div>
+  </>
+);
+
+const { details, editYaml } = navFactory;
+export const EnvoyFilters: React.FC = props => <Table {...props} aria-label="Envoy Filters" Header={EnvoyFilterTableHeader} Row={EnvoyFilterTableRow} virtualize />;
+
+export const EnvoyFiltersPage: React.FC<EnvoyFiltersPageProps> = props => <ListPage canCreate={true} ListComponent={EnvoyFilters} kind={kind} {...props} />;
+
+export const EnvoyFiltersDetailsPage: React.FC<EnvoyFiltersDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(EnvoyFilterDetails)), editYaml()]} />;
+
+type EnvoyFilterDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type EnvoyFiltersPageProps = {
+  showTitle?: boolean;
+  namespace?: string;
+  selector?: any;
+};
+
+type EnvoyFiltersDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/hypercloud/gateway.tsx
+++ b/frontend/public/components/hypercloud/gateway.tsx
@@ -1,0 +1,99 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { sortable } from '@patternfly/react-table';
+
+import { K8sResourceKind } from '../../module/k8s';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from '../factory';
+import { Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
+import { Status } from '@console/shared';
+import { GatewayModel } from '../../models';
+
+export const menuActions: KebabAction[] = [...Kebab.getExtensionsActionsForKind(GatewayModel), ...Kebab.factory.common];
+
+const kind = GatewayModel.kind;
+
+const tableColumnClasses = ['', '', classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'), Kebab.columnClass];
+
+const GatewayTableHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortFunc: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Created',
+      sortField: 'metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[3] },
+    },
+  ];
+};
+GatewayTableHeader.displayName = 'GatewayTableHeader';
+
+const GatewayTableRow: RowFunction<K8sResourceKind> = ({ obj: gateway, index, key, style }) => {
+  return (
+    <TableRow id={gateway.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink kind={kind} name={gateway.metadata.name} namespace={gateway.metadata.namespace} title={gateway.metadata.uid} />
+      </TableData>
+      <TableData className={tableColumnClasses[1]}>
+        <Status status={gateway.metadata.namespace} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
+        <Timestamp timestamp={gateway.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <ResourceKebab actions={menuActions} kind={kind} resource={gateway} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+const GatewayDetails: React.FC<GatewayDetailsProps> = ({ obj: gateway }) => (
+  <>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Gateway Details" />
+      <div className="row">
+        <div className="col-lg-6">
+          <ResourceSummary resource={gateway} />
+        </div>
+      </div>
+    </div>
+    <div className="co-m-pane__body">
+    </div>
+  </>
+);
+
+const { details, editYaml } = navFactory;
+export const Gateways: React.FC = props => <Table {...props} aria-label="Gateways" Header={GatewayTableHeader} Row={GatewayTableRow} virtualize />;
+
+export const GatewaysPage: React.FC<GatewaysPageProps> = props => <ListPage canCreate={true} ListComponent={Gateways} kind={kind} {...props} />;
+
+export const GatewaysDetailsPage: React.FC<GatewaysDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(GatewayDetails)), editYaml()]} />;
+
+type GatewayDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type GatewaysPageProps = {
+  showTitle?: boolean;
+  namespace?: string;
+  selector?: any;
+};
+
+type GatewaysDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/hypercloud/kiali.jsx
+++ b/frontend/public/components/hypercloud/kiali.jsx
@@ -1,0 +1,59 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import { Helmet } from 'react-helmet';
+import * as PropTypes from 'prop-types';
+
+import { history, PageHeading } from '../utils';
+import { namespaceProptype } from '../../propTypes';
+import { connectToFlags, flagPending } from '../../reducers/features';
+import { FLAGS } from '@console/shared';
+
+const updateUrlParams = (k, v) => {
+    const url = new URL(window.location);
+    const sp = new URLSearchParams(window.location.search);
+    sp.set(k, v);
+    history.push(`${url.pathname}?${sp.toString()}${url.hash}`);
+};
+
+const updateKind = kind => updateUrlParams('kind', encodeURIComponent(kind));
+
+class KialiPage_ extends React.PureComponent {
+    constructor(props) {
+        super(props);
+        this.setRef = ref => (this.ref = ref);
+        this.onSelectorChange = k => {
+            updateKind(k);
+            this.ref && this.ref.focus();
+        };
+    }
+
+    render() {
+        const { flags, location, namespace, t } = this.props;
+
+        // if (flagPending(flags.OPENSHIFT) || flagPending(flags.PROJECTS_AVAILABLE)) {
+        //     return null;
+        // }
+        let url = `${document.location.origin}/api/kiali`
+        return (
+            <React.Fragment>
+                <div>
+                    <Helmet>
+                        <title>Kiali</title>
+                    </Helmet>
+                    <PageHeading title='Kiali'>
+                    </PageHeading>
+                    {/* <script>parent.location={url}</script> */}
+                    <iframe style={{ width: '100%', height: '100vh', border: 0 }} src={url} target="_blank" />
+                </div>
+            </React.Fragment>
+        );
+    }
+}
+
+export const KialiPage = props => <KialiPage_ {...props}/>;
+// export const KialiPage = connectToFlags(FLAGS.OPENSHIFT, FLAGS.PROJECT)(KialiPage_)
+
+KialiPage.propTypes = {
+    namespace: namespaceProptype,
+    location: PropTypes.object.isRequired,
+};

--- a/frontend/public/components/hypercloud/nav/hypercloud-nav.tsx
+++ b/frontend/public/components/hypercloud/nav/hypercloud-nav.tsx
@@ -26,6 +26,7 @@ const HyperCloudNav = () => (
           <ResourceNSLink resource="events" name="Events" />
           <HrefLink href="/grafana" name="Grafana" />
         </NavSection>
+        <NavSection title="Operators" />
         <NavSection title={t('COMMON:MSG_LNB_MENU_10')}>
           <ResourceNSLink resource="servicebrokers" name="Service Broker" />
           <ResourceNSLink resource="serviceclasses" name="Service Class" />

--- a/frontend/public/components/hypercloud/peer-authentication.tsx
+++ b/frontend/public/components/hypercloud/peer-authentication.tsx
@@ -1,0 +1,99 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { sortable } from '@patternfly/react-table';
+
+import { K8sResourceKind } from '../../module/k8s';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from '../factory';
+import { Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
+import { Status } from '@console/shared';
+import { PeerAuthenticationModel } from '../../models';
+
+export const menuActions: KebabAction[] = [...Kebab.getExtensionsActionsForKind(PeerAuthenticationModel), ...Kebab.factory.common];
+
+const kind = PeerAuthenticationModel.kind;
+
+const tableColumnClasses = ['', '', classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'), Kebab.columnClass];
+
+const PeerAuthenticationTableHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortFunc: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Created',
+      sortField: 'metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[3] },
+    },
+  ];
+};
+PeerAuthenticationTableHeader.displayName = 'PeerAuthenticationTableHeader';
+
+const PeerAuthenticationTableRow: RowFunction<K8sResourceKind> = ({ obj: peerauthentication, index, key, style }) => {
+  return (
+    <TableRow id={peerauthentication.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink kind={kind} name={peerauthentication.metadata.name} namespace={peerauthentication.metadata.namespace} title={peerauthentication.metadata.uid} />
+      </TableData>
+      <TableData className={tableColumnClasses[1]}>
+        <Status status={peerauthentication.metadata.namespace} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
+        <Timestamp timestamp={peerauthentication.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <ResourceKebab actions={menuActions} kind={kind} resource={peerauthentication} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+const PeerAuthenticationDetails: React.FC<PeerAuthenticationDetailsProps> = ({ obj: peerauthentication }) => (
+  <>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Peer Authentication Details" />
+      <div className="row">
+        <div className="col-lg-6">
+          <ResourceSummary resource={peerauthentication} />
+        </div>
+      </div>
+    </div>
+    <div className="co-m-pane__body">
+    </div>
+  </>
+);
+
+const { details, editYaml } = navFactory;
+export const PeerAuthentications: React.FC = props => <Table {...props} aria-label="Peer Authentications" Header={PeerAuthenticationTableHeader} Row={PeerAuthenticationTableRow} virtualize />;
+
+export const PeerAuthenticationsPage: React.FC<PeerAuthenticationsPageProps> = props => <ListPage canCreate={true} ListComponent={PeerAuthentications} kind={kind} {...props} />;
+
+export const PeerAuthenticationsDetailsPage: React.FC<PeerAuthenticationsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(PeerAuthenticationDetails)), editYaml()]} />;
+
+type PeerAuthenticationDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type PeerAuthenticationsPageProps = {
+  showTitle?: boolean;
+  namespace?: string;
+  selector?: any;
+};
+
+type PeerAuthenticationsDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/hypercloud/request-authentication.tsx
+++ b/frontend/public/components/hypercloud/request-authentication.tsx
@@ -1,0 +1,99 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { sortable } from '@patternfly/react-table';
+
+import { K8sResourceKind } from '../../module/k8s';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from '../factory';
+import { Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
+import { Status } from '@console/shared';
+import { RequestAuthenticationModel } from '../../models';
+
+export const menuActions: KebabAction[] = [...Kebab.getExtensionsActionsForKind(RequestAuthenticationModel), ...Kebab.factory.common];
+
+const kind = RequestAuthenticationModel.kind;
+
+const tableColumnClasses = ['', '', classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'), Kebab.columnClass];
+
+const RequestAuthenticationTableHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortFunc: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Created',
+      sortField: 'metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[3] },
+    },
+  ];
+};
+RequestAuthenticationTableHeader.displayName = 'RequestAuthenticationTableHeader';
+
+const RequestAuthenticationTableRow: RowFunction<K8sResourceKind> = ({ obj: requestauthentication, index, key, style }) => {
+  return (
+    <TableRow id={requestauthentication.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink kind={kind} name={requestauthentication.metadata.name} namespace={requestauthentication.metadata.namespace} title={requestauthentication.metadata.uid} />
+      </TableData>
+      <TableData className={tableColumnClasses[1]}>
+        <Status status={requestauthentication.metadata.namespace} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
+        <Timestamp timestamp={requestauthentication.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <ResourceKebab actions={menuActions} kind={kind} resource={requestauthentication} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+const RequestAuthenticationDetails: React.FC<RequestAuthenticationDetailsProps> = ({ obj: requestauthentication }) => (
+  <>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Request Authentication Details" />
+      <div className="row">
+        <div className="col-lg-6">
+          <ResourceSummary resource={requestauthentication} />
+        </div>
+      </div>
+    </div>
+    <div className="co-m-pane__body">
+    </div>
+  </>
+);
+
+const { details, editYaml } = navFactory;
+export const RequestAuthentications: React.FC = props => <Table {...props} aria-label="Request Authentications" Header={RequestAuthenticationTableHeader} Row={RequestAuthenticationTableRow} virtualize />;
+
+export const RequestAuthenticationsPage: React.FC<RequestAuthenticationsPageProps> = props => <ListPage canCreate={true} ListComponent={RequestAuthentications} kind={kind} {...props} />;
+
+export const RequestAuthenticationsDetailsPage: React.FC<RequestAuthenticationsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(RequestAuthenticationDetails)), editYaml()]} />;
+
+type RequestAuthenticationDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type RequestAuthenticationsPageProps = {
+  showTitle?: boolean;
+  namespace?: string;
+  selector?: any;
+};
+
+type RequestAuthenticationsDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/hypercloud/resource-pages.ts
+++ b/frontend/public/components/hypercloud/resource-pages.ts
@@ -1,6 +1,8 @@
 import { Map as ImmutableMap } from 'immutable';
 import { referenceForModel, GroupVersionKind } from '../../module/k8s';
-import { ApprovalModel, HyperClusterResourceModel, FederatedConfigMapModel,FederatedDeploymentModel, FederatedIngressModel, FederatedNamespaceModel, FederatedJobModel, FederatedReplicaSetModel, FederatedSecretModel, FederatedServiceModel, FederatedPodModel, FederatedHPAModel, FederatedDaemonSetModel, FederatedStatefulSetModel, FederatedCronJobModel } from '../../models';
+import { ApprovalModel, HyperClusterResourceModel, FederatedConfigMapModel,FederatedDeploymentModel, FederatedIngressModel, FederatedNamespaceModel, FederatedJobModel, FederatedReplicaSetModel, FederatedSecretModel, FederatedServiceModel, FederatedPodModel, FederatedHPAModel, FederatedDaemonSetModel, FederatedStatefulSetModel, FederatedCronJobModel,
+  VirtualMachineModel, VirtualMachineInstanceModel, VirtualServiceModel, DestinationRuleModel, EnvoyFilterModel, GatewayModel, SidecarModel, ServiceEntryModel, RequestAuthenticationModel, PeerAuthenticationModel, AuthorizationPolicyModel, DataVolumeModel } from '../../models';
+
 
 type ResourceMapKey = GroupVersionKind | string;
 type ResourceMapValue = () => Promise<React.ComponentType<any>>;
@@ -20,7 +22,19 @@ export const hyperCloudDetailsPages = ImmutableMap<ResourceMapKey, ResourceMapVa
   .set(referenceForModel(FederatedHPAModel), () => import('./federated-horizontalpodautoscaler' /* webpackChunkName: "horizontalpodautoscaler" */).then((m) => m.FederatedHPAsDetailsPage))
   .set(referenceForModel(FederatedDaemonSetModel), () => import('./federated-daemonset' /* webpackChunkName: "daemonset" */).then((m) => m.FederatedDaemonSetsDetailsPage))
   .set(referenceForModel(FederatedStatefulSetModel), () => import('./federated-statefulset' /* webpackChunkName: "statefulset" */).then((m) => m.FederatedStatefulSetsDetailsPage))
-  .set(referenceForModel(FederatedCronJobModel), () => import('./federated-cronjob' /* webpackChunkName: "cronjob" */).then((m) => m.FederatedCronJobsDetailsPage));
+  .set(referenceForModel(FederatedCronJobModel), () => import('./federated-cronjob' /* webpackChunkName: "cronjob" */).then((m) => m.FederatedCronJobsDetailsPage))
+  .set(referenceForModel(VirtualMachineModel), () => import('./virtual-machine' /* webpackChunkName: "virtual-machine" */).then(m => m.VirtualMachinesDetailsPage))
+  .set(referenceForModel(VirtualMachineInstanceModel), () => import('./virtual-machine-instance' /* webpackChunkName: "virtual-machine-instance" */).then(m => m.VirtualMachineInstancesDetailsPage))
+  .set(referenceForModel(VirtualServiceModel), () => import('./virtual-service' /* webpackChunkName: "virtual-service" */).then(m => m.VirtualServicesDetailsPage))
+  .set(referenceForModel(DestinationRuleModel), () => import('./destination-rule' /* webpackChunkName: "destination-rule" */).then(m => m.DestinationRulesDetailsPage))
+  .set(referenceForModel(EnvoyFilterModel), () => import('./envoy-filter' /* webpackChunkName: "envoy-filter" */).then(m => m.EnvoyFiltersDetailsPage))
+  .set(referenceForModel(GatewayModel), () => import('./gateway' /* webpackChunkName: "gateway" */).then(m => m.GatewaysDetailsPage))
+  .set(referenceForModel(SidecarModel), () => import('./sidecar' /* webpackChunkName: "sidecar" */).then(m => m.SidecarsDetailsPage))
+  .set(referenceForModel(ServiceEntryModel), () => import('./service-entry' /* webpackChunkName: "service-entry" */).then(m => m.ServiceEntriesDetailsPage))
+  .set(referenceForModel(RequestAuthenticationModel), () => import('./request-authentication' /* webpackChunkName: "request-authentication" */).then(m => m.RequestAuthenticationsDetailsPage))
+  .set(referenceForModel(PeerAuthenticationModel), () => import('./peer-authentication' /* webpackChunkName: "peer-authentication" */).then(m => m.PeerAuthenticationsDetailsPage))
+  .set(referenceForModel(AuthorizationPolicyModel), () => import('./authentication-policy' /* webpackChunkName: "authentication-policy" */).then(m => m.AuthorizationPoliciesDetailsPage))
+  .set(referenceForModel(DataVolumeModel), () => import('./data-volume' /* webpackChunkName: "data-volume" */).then(m => m.DataVolumesDetailsPage));
 
 export const hyperCloudListPages = ImmutableMap<ResourceMapKey, ResourceMapValue>()
   .set(referenceForModel(ApprovalModel), () => import('./approval' /* webpackChunkName: "approval" */).then(m => m.ApprovalsPage))
@@ -37,4 +51,16 @@ export const hyperCloudListPages = ImmutableMap<ResourceMapKey, ResourceMapValue
   .set(referenceForModel(FederatedHPAModel), () => import('./federated-horizontalpodautoscaler' /* webpackChunkName: "horizontalpodautoscaler" */).then((m) => m.FederatedHPAsPage))
   .set(referenceForModel(FederatedDaemonSetModel), () => import('./federated-daemonset' /* webpackChunkName: "daemonset" */).then((m) => m.FederatedDaemonSetsPage))
   .set(referenceForModel(FederatedStatefulSetModel), () => import('./federated-statefulset' /* webpackChunkName: "statefulset" */).then((m) => m.FederatedStatefulSetsPage))
-  .set(referenceForModel(FederatedCronJobModel), () => import('./federated-cronjob' /* webpackChunkName: "cronjob" */).then((m) => m.FederatedCronJobsPage));
+  .set(referenceForModel(FederatedCronJobModel), () => import('./federated-cronjob' /* webpackChunkName: "cronjob" */).then((m) => m.FederatedCronJobsPage))
+  .set(referenceForModel(VirtualMachineModel), () => import('./virtual-machine' /* webpackChunkName: "virtual-machine" */).then(m => m.VirtualMachinesPage))
+  .set(referenceForModel(VirtualMachineInstanceModel), () => import('./virtual-machine-instance' /* webpackChunkName: "virtual-machine-instance" */).then(m => m.VirtualMachineInstancesPage))
+  .set(referenceForModel(VirtualServiceModel), () => import('./virtual-service' /* webpackChunkName: "virtual-service" */).then(m => m.VirtualServicesPage))
+  .set(referenceForModel(DestinationRuleModel), () => import('./destination-rule' /* webpackChunkName: "destination-rule" */).then(m => m.DestinationRulesPage))
+  .set(referenceForModel(EnvoyFilterModel), () => import('./envoy-filter' /* webpackChunkName: "envoy-filter" */).then(m => m.EnvoyFiltersPage))
+  .set(referenceForModel(GatewayModel), () => import('./gateway' /* webpackChunkName: "gateway" */).then(m => m.GatewaysPage))
+  .set(referenceForModel(SidecarModel), () => import('./sidecar' /* webpackChunkName: "sidecar" */).then(m => m.SidecarsPage))
+  .set(referenceForModel(ServiceEntryModel), () => import('./service-entry' /* webpackChunkName: "service-entry" */).then(m => m.ServiceEntriesPage))
+  .set(referenceForModel(RequestAuthenticationModel), () => import('./request-authentication' /* webpackChunkName: "request-authentication" */).then(m => m.RequestAuthenticationsPage))
+  .set(referenceForModel(PeerAuthenticationModel), () => import('./peer-authentication' /* webpackChunkName: "peer-authentication" */).then(m => m.PeerAuthenticationsPage))
+  .set(referenceForModel(AuthorizationPolicyModel), () => import('./authentication-policy' /* webpackChunkName: "authentication-policy" */).then(m => m.AuthorizationPoliciesPage))
+  .set(referenceForModel(DataVolumeModel), () => import('./data-volume' /* webpackChunkName: "data-volume" */).then(m => m.DataVolumesPage));

--- a/frontend/public/components/hypercloud/service-entry.tsx
+++ b/frontend/public/components/hypercloud/service-entry.tsx
@@ -1,0 +1,99 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { sortable } from '@patternfly/react-table';
+
+import { K8sResourceKind } from '../../module/k8s';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from '../factory';
+import { Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
+import { Status } from '@console/shared';
+import { ServiceEntryModel } from '../../models';
+
+export const menuActions: KebabAction[] = [...Kebab.getExtensionsActionsForKind(ServiceEntryModel), ...Kebab.factory.common];
+
+const kind = ServiceEntryModel.kind;
+
+const tableColumnClasses = ['', '', classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'), Kebab.columnClass];
+
+const ServiceEntryTableHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortFunc: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Created',
+      sortField: 'metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[3] },
+    },
+  ];
+};
+ServiceEntryTableHeader.displayName = 'ServiceEntryTableHeader';
+
+const ServiceEntryTableRow: RowFunction<K8sResourceKind> = ({ obj: serviceentry, index, key, style }) => {
+  return (
+    <TableRow id={serviceentry.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink kind={kind} name={serviceentry.metadata.name} namespace={serviceentry.metadata.namespace} title={serviceentry.metadata.uid} />
+      </TableData>
+      <TableData className={tableColumnClasses[1]}>
+        <Status status={serviceentry.metadata.namespace} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
+        <Timestamp timestamp={serviceentry.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <ResourceKebab actions={menuActions} kind={kind} resource={serviceentry} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+const ServiceEntryDetails: React.FC<ServiceEntryDetailsProps> = ({ obj: serviceentry }) => (
+  <>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Authorization Policy Details" />
+      <div className="row">
+        <div className="col-lg-6">
+          <ResourceSummary resource={serviceentry} />
+        </div>
+      </div>
+    </div>
+    <div className="co-m-pane__body">
+    </div>
+  </>
+);
+
+const { details, editYaml } = navFactory;
+export const ServiceEntries: React.FC = props => <Table {...props} aria-label="Service Entries" Header={ServiceEntryTableHeader} Row={ServiceEntryTableRow} virtualize />;
+
+export const ServiceEntriesPage: React.FC<ServiceEntriesPageProps> = props => <ListPage canCreate={true} ListComponent={ServiceEntries} kind={kind} {...props} />;
+
+export const ServiceEntriesDetailsPage: React.FC<ServiceEntriesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(ServiceEntryDetails)), editYaml()]} />;
+
+type ServiceEntryDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type ServiceEntriesPageProps = {
+  showTitle?: boolean;
+  namespace?: string;
+  selector?: any;
+};
+
+type ServiceEntriesDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/hypercloud/sidecar.tsx
+++ b/frontend/public/components/hypercloud/sidecar.tsx
@@ -1,0 +1,99 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { sortable } from '@patternfly/react-table';
+
+import { K8sResourceKind } from '../../module/k8s';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from '../factory';
+import { Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
+import { Status } from '@console/shared';
+import { SidecarModel } from '../../models';
+
+export const menuActions: KebabAction[] = [...Kebab.getExtensionsActionsForKind(SidecarModel), ...Kebab.factory.common];
+
+const kind = SidecarModel.kind;
+
+const tableColumnClasses = ['', '', classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'), Kebab.columnClass];
+
+const SidecarTableHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortFunc: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Created',
+      sortField: 'metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[3] },
+    },
+  ];
+};
+SidecarTableHeader.displayName = 'SidecarTableHeader';
+
+const SidecarTableRow: RowFunction<K8sResourceKind> = ({ obj: sidecar, index, key, style }) => {
+  return (
+    <TableRow id={sidecar.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink kind={kind} name={sidecar.metadata.name} namespace={sidecar.metadata.namespace} title={sidecar.metadata.uid} />
+      </TableData>
+      <TableData className={tableColumnClasses[1]}>
+        <Status status={sidecar.metadata.namespace} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
+        <Timestamp timestamp={sidecar.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <ResourceKebab actions={menuActions} kind={kind} resource={sidecar} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+const SidecarDetails: React.FC<SidecarDetailsProps> = ({ obj: sidecar }) => (
+  <>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Sidecar Details" />
+      <div className="row">
+        <div className="col-lg-6">
+          <ResourceSummary resource={sidecar} />
+        </div>
+      </div>
+    </div>
+    <div className="co-m-pane__body">
+    </div>
+  </>
+);
+
+const { details, editYaml } = navFactory;
+export const Sidecars: React.FC = props => <Table {...props} aria-label="Sidecars" Header={SidecarTableHeader} Row={SidecarTableRow} virtualize />;
+
+export const SidecarsPage: React.FC<SidecarsPageProps> = props => <ListPage canCreate={true} ListComponent={Sidecars} kind={kind} {...props} />;
+
+export const SidecarsDetailsPage: React.FC<SidecarsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(SidecarDetails)), editYaml()]} />;
+
+type SidecarDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type SidecarsPageProps = {
+  showTitle?: boolean;
+  namespace?: string;
+  selector?: any;
+};
+
+type SidecarsDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/hypercloud/virtual-machine-instance.tsx
+++ b/frontend/public/components/hypercloud/virtual-machine-instance.tsx
@@ -1,0 +1,99 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { sortable } from '@patternfly/react-table';
+
+import { K8sResourceKind } from '../../module/k8s';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from '../factory';
+import { Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
+import { Status } from '@console/shared';
+import { VirtualMachineInstanceModel } from '../../models';
+
+export const menuActions: KebabAction[] = [...Kebab.getExtensionsActionsForKind(VirtualMachineInstanceModel), ...Kebab.factory.common];
+
+const kind = VirtualMachineInstanceModel.kind;
+
+const tableColumnClasses = ['', '', classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'), Kebab.columnClass];
+
+const VirtualMachineInstanceTableHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortFunc: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Created',
+      sortField: 'metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[3] },
+    },
+  ];
+};
+VirtualMachineInstanceTableHeader.displayName = 'VirtualMachineInstanceTableHeader';
+
+const VirtualMachineInstanceTableRow: RowFunction<K8sResourceKind> = ({ obj: virtualmachineinstance, index, key, style }) => {
+  return (
+    <TableRow id={virtualmachineinstance.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink kind={kind} name={virtualmachineinstance.metadata.name} namespace={virtualmachineinstance.metadata.namespace} title={virtualmachineinstance.metadata.uid} />
+      </TableData>
+      <TableData className={tableColumnClasses[1]}>
+        <Status status={virtualmachineinstance.metadata.namespace} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
+        <Timestamp timestamp={virtualmachineinstance.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <ResourceKebab actions={menuActions} kind={kind} resource={virtualmachineinstance} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+const VirtualMachineInstanceDetails: React.FC<VirtualMachineInstanceDetailsProps> = ({ obj: virtualmachineinstance }) => (
+  <>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Virtual Machine Instance Details" />
+      <div className="row">
+        <div className="col-lg-6">
+          <ResourceSummary resource={virtualmachineinstance} />
+        </div>
+      </div>
+    </div>
+    <div className="co-m-pane__body">
+    </div>
+  </>
+);
+
+const { details, editYaml } = navFactory;
+export const VirtualMachineInstances: React.FC = props => <Table {...props} aria-label="Virtual Machine Instances" Header={VirtualMachineInstanceTableHeader} Row={VirtualMachineInstanceTableRow} virtualize />;
+
+export const VirtualMachineInstancesPage: React.FC<VirtualMachineInstancesPageProps> = props => <ListPage canCreate={true} ListComponent={VirtualMachineInstances} kind={kind} {...props} />;
+
+export const VirtualMachineInstancesDetailsPage: React.FC<VirtualMachineInstancesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(VirtualMachineInstanceDetails)), editYaml()]} />;
+
+type VirtualMachineInstanceDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type VirtualMachineInstancesPageProps = {
+  showTitle?: boolean;
+  namespace?: string;
+  selector?: any;
+};
+
+type VirtualMachineInstancesDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/hypercloud/virtual-machine.tsx
+++ b/frontend/public/components/hypercloud/virtual-machine.tsx
@@ -1,0 +1,99 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { sortable } from '@patternfly/react-table';
+
+import { K8sResourceKind } from '../../module/k8s';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from '../factory';
+import { Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
+import { Status } from '@console/shared';
+import { VirtualMachineModel } from '../../models';
+
+export const menuActions: KebabAction[] = [...Kebab.getExtensionsActionsForKind(VirtualMachineModel), ...Kebab.factory.common];
+
+const kind = VirtualMachineModel.kind;
+
+const tableColumnClasses = ['', '', classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'), Kebab.columnClass];
+
+const VirtualMachineTableHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortFunc: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Created',
+      sortField: 'metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[3] },
+    },
+  ];
+};
+VirtualMachineTableHeader.displayName = 'VirtualMachineTableHeader';
+
+const VirtualMachineTableRow: RowFunction<K8sResourceKind> = ({ obj: virtualmachine, index, key, style }) => {
+  return (
+    <TableRow id={virtualmachine.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink kind={kind} name={virtualmachine.metadata.name} namespace={virtualmachine.metadata.namespace} title={virtualmachine.metadata.uid} />
+      </TableData>
+      <TableData className={tableColumnClasses[1]}>
+        <Status status={virtualmachine.metadata.namespace} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
+        <Timestamp timestamp={virtualmachine.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <ResourceKebab actions={menuActions} kind={kind} resource={virtualmachine} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+const VirtualMachineDetails: React.FC<VirtualMachineDetailsProps> = ({ obj: virtualmachine }) => (
+  <>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Virtual Machine Details" />
+      <div className="row">
+        <div className="col-lg-6">
+          <ResourceSummary resource={virtualmachine} />
+        </div>
+      </div>
+    </div>
+    <div className="co-m-pane__body">
+    </div>
+  </>
+);
+
+const { details, editYaml } = navFactory;
+export const VirtualMachines: React.FC = props => <Table {...props} aria-label="Virtual Machines" Header={VirtualMachineTableHeader} Row={VirtualMachineTableRow} virtualize />;
+
+export const VirtualMachinesPage: React.FC<VirtualMachinesPageProps> = props => <ListPage canCreate={true} ListComponent={VirtualMachines} kind={kind} {...props} />;
+
+export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(VirtualMachineDetails)), editYaml()]} />;
+
+type VirtualMachineDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type VirtualMachinesPageProps = {
+  showTitle?: boolean;
+  namespace?: string;
+  selector?: any;
+};
+
+type VirtualMachinesDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/hypercloud/virtual-service.tsx
+++ b/frontend/public/components/hypercloud/virtual-service.tsx
@@ -1,0 +1,120 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { sortable } from '@patternfly/react-table';
+
+import { K8sResourceKind } from '../../module/k8s';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from '../factory';
+import { Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
+import { Status } from '@console/shared';
+import { VirtualServiceModel } from '../../models';
+
+export const menuActions: KebabAction[] = [...Kebab.getExtensionsActionsForKind(VirtualServiceModel), ...Kebab.factory.common];
+
+const kind = VirtualServiceModel.kind;
+
+const tableColumnClasses = ['', '', classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'), classNames('pf-m-hidden', 'pf-m-visible-on-lg'), classNames('pf-m-hidden', 'pf-m-visible-on-lg'), Kebab.columnClass];
+
+const VirtualServiceTableHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortFunc: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Host',
+      sortField: 'spec.hosts',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: 'Gateway',
+      sortField: 'spec.gateways',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[3] },
+    },
+    {
+      title: 'Created',
+      sortField: 'metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[4] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[5] },
+    },
+  ];
+};
+VirtualServiceTableHeader.displayName = 'VirtualServiceTableHeader';
+
+const VirtualServiceTableRow: RowFunction<K8sResourceKind> = ({ obj: virtualservice, index, key, style }) => {
+  let hosts = virtualservice.spec.hosts ? virtualservice.spec.hosts.map(host => host + ' ') : '';
+  let gateways = virtualservice.spec.gateways ? virtualservice.spec.gateways.map(gateway => gateway + ' ') : '';
+
+  return (
+    <TableRow id={virtualservice.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink kind={kind} name={virtualservice.metadata.name} namespace={virtualservice.metadata.namespace} title={virtualservice.metadata.uid} />
+      </TableData>
+      <TableData className={tableColumnClasses[1]}>
+        <Status status={virtualservice.metadata.namespace} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
+        {hosts}
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        {gateways}
+      </TableData>
+      <TableData className={tableColumnClasses[4]}>
+        <Timestamp timestamp={virtualservice.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={tableColumnClasses[5]}>
+        <ResourceKebab actions={menuActions} kind={kind} resource={virtualservice} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+const VirtualServiceDetails: React.FC<VirtualServiceDetailsProps> = ({ obj: virtualservice }) => (
+  <>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Virtual Service Details" />
+      <div className="row">
+        <div className="col-lg-6">
+          <ResourceSummary resource={virtualservice} />
+        </div>
+      </div>
+    </div>
+    <div className="co-m-pane__body">
+    </div>
+  </>
+);
+
+const { details, editYaml } = navFactory;
+export const VirtualServices: React.FC = props => <Table {...props} aria-label="Virtual Services" Header={VirtualServiceTableHeader} Row={VirtualServiceTableRow} virtualize />;
+
+export const VirtualServicesPage: React.FC<VirtualServicesPageProps> = props => <ListPage canCreate={true} ListComponent={VirtualServices} kind={kind} {...props} />;
+
+export const VirtualServicesDetailsPage: React.FC<VirtualServicesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(VirtualServiceDetails)), editYaml()]} />;
+
+type VirtualServiceDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type VirtualServicesPageProps = {
+  showTitle?: boolean;
+  namespace?: string;
+  selector?: any;
+};
+
+type VirtualServicesDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -122,18 +122,18 @@ export const NavSection = connect(navSectionStateToProps)(
       };
 
       getNavItemExtensions = (perspective: string, section: string) => {
-        const { navItemExtensions, perspectiveExtensions } = this.props;
+        const { navItemExtensions /*, perspectiveExtensions*/ } = this.props;
 
-        const defaultPerspective = _.find(perspectiveExtensions, (p) => p.properties.default);
-        const isDefaultPerspective =
-          defaultPerspective && perspective === defaultPerspective.properties.id;
+        // const defaultPerspective = _.find(perspectiveExtensions, (p) => p.properties.default);
+        // const isDefaultPerspective =
+        //   defaultPerspective && perspective === defaultPerspective.properties.id;
 
         return navItemExtensions.filter(
           (item) =>
             // check if the item is contributed to the current perspective,
             // or if no perspective specified, are we in the default perspective
-            (item.properties.perspective === perspective ||
-              (!item.properties.perspective && isDefaultPerspective)) &&
+            // (item.properties.perspective === perspective ||
+            //   (!item.properties.perspective && isDefaultPerspective)) &&
             item.properties.section === section,
         );
       };

--- a/frontend/public/models/hypercloud/index.ts
+++ b/frontend/public/models/hypercloud/index.ts
@@ -296,3 +296,147 @@ export const ConditionModel: K8sKind = {
   id: 'condition',
   crd: false,
 };
+
+export const VirtualMachineModel: K8sKind = {
+  label: 'VirtualMachine',
+  labelPlural: 'VirtualMachines',
+  apiVersion: 'v1alpha3',
+  apiGroup: 'kubevirt.io',
+  plural: 'virtualmachines',
+  abbr: 'vm',
+  kind: 'VirtualMachine',
+  id: 'virtualmachine',
+  namespaced: true,
+};
+
+export const VirtualMachineInstanceModel: K8sKind = {
+  label: 'VirtualMachineInstance',
+  labelPlural: 'VirtualMachineInstances',
+  apiVersion: 'v1alpha3',
+  apiGroup: 'kubevirt.io',
+  plural: 'virtualmachineinstances',
+  abbr: 'vmi',
+  kind: 'VirtualMachineInstance',
+  id: 'virtualmachineinstance',
+  namespaced: true,
+};
+
+export const VirtualServiceModel: K8sKind = {
+  label: 'Virtual Service',
+  labelPlural: 'Virtual Services',
+  apiVersion: 'v1alpha3',
+  apiGroup: 'networking.istio.io',
+  plural: 'virtualservices',
+  abbr: 'vs',
+  kind: 'VirtualService',
+  id: 'virtualservice',
+  namespaced: true,
+};
+
+export const DestinationRuleModel: K8sKind = {
+  label: 'Destination Rule',
+  labelPlural: 'Destination Rules',
+  apiVersion: 'v1alpha3',
+  apiGroup: 'networking.istio.io',
+  plural: 'destinationrules',
+  abbr: 'dr',
+  kind: 'DestinationRule',
+  id: 'destinationrule',
+  namespaced: true,
+};
+
+export const EnvoyFilterModel: K8sKind = {
+  label: 'Envoy Filter',
+  labelPlural: 'Envoy Filters',
+  apiVersion: 'v1alpha3',
+  apiGroup: 'networking.istio.io',
+  plural: 'envoyfilters',
+  abbr: 'ef',
+  kind: 'EnvoyFilter',
+  id: 'envoyfilter',
+  namespaced: true,
+};
+
+export const GatewayModel: K8sKind = {
+  label: 'Gateway',
+  labelPlural: 'Gateways',
+  apiVersion: 'v1alpha3',
+  apiGroup: 'networking.istio.io',
+  plural: 'gateways',
+  abbr: 'g',
+  kind: 'Gateway',
+  id: 'gateway',
+  namespaced: true,
+};
+
+export const SidecarModel: K8sKind = {
+  label: 'Sidecar',
+  labelPlural: 'Sidecars',
+  apiVersion: 'v1alpha3',
+  apiGroup: 'networking.istio.io',
+  plural: 'sidecars',
+  abbr: 'sc',
+  kind: 'Sidecar',
+  id: 'sidecar',
+  namespaced: true,
+};
+
+export const ServiceEntryModel: K8sKind = {
+  label: 'Service Entry',
+  labelPlural: 'Service Entries',
+  apiVersion: 'v1alpha3',
+  apiGroup: 'networking.istio.io',
+  plural: 'serviceentries',
+  abbr: 'se',
+  kind: 'ServiceEntry',
+  id: 'serviceentry',
+  namespaced: true,
+};
+
+export const RequestAuthenticationModel: K8sKind = {
+  label: 'Request Authentication',
+  labelPlural: 'Request Authentications',
+  apiVersion: 'v1beta1',
+  apiGroup: 'security.istio.io',
+  plural: 'requestauthentications',
+  abbr: 'ra',
+  kind: 'RequestAuthentication',
+  id: 'requestauthentication',
+  namespaced: true,
+};
+
+export const PeerAuthenticationModel: K8sKind = {
+  label: 'Peer Authentication',
+  labelPlural: 'Peer Authentications',
+  apiVersion: 'v1beta1',
+  apiGroup: 'security.istio.io',
+  plural: 'peerauthentications',
+  abbr: 'pa',
+  kind: 'PeerAuthentication',
+  id: 'peerauthentication',
+  namespaced: true,
+};
+
+export const AuthorizationPolicyModel: K8sKind = {
+  label: 'Authorization Policy',
+  labelPlural: 'Authorization Policies',
+  apiVersion: 'v1beta1',
+  apiGroup: 'security.istio.io',
+  plural: 'authorizationpolicies',
+  abbr: 'ap',
+  namespaced: true,
+  kind: 'AuthorizationPolicy',
+  id: 'authorizationpolicy',
+};
+
+export const DataVolumeModel: K8sKind = {
+  label: 'Data Volume',
+  labelPlural: 'Data Volumes',
+  apiVersion: 'v1alpha1',
+  apiGroup: 'cdi.kubevirt.io',
+  plural: 'datavolumes',
+  abbr: 'dv',
+  kind: 'DataVolume',
+  id: 'datavolume',
+  namespaced: true,
+};


### PR DESCRIPTION
#### What: 담당 메뉴(VM, VMI, DV, 서비스메시)의 리스트, 디테일 페이지 추가 & 오퍼레이터 메뉴 추가

#### How: 기존 리스트&디테일 페이지 활용, @console/kubevirt-plugin 이용