### PR TITLE
[feat] vm 메뉴의 의도하지 않은 라우팅 규칙 삭제 및 vmi 생성 버튼 삭제

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -155,108 +155,108 @@ const plugin: Plugin<ConsumedExtensions> = [
       templateName: 'vm-template',
     },
   },
-  {
-    type: 'Page/Route',
-    properties: {
-      exact: true,
-      path: ['/k8s/ns/:ns/virtualization/~new'],
-      loader: () =>
-        import('./components/vms/vm-create-yaml' /* webpackChunkName: "kubevirt" */).then(
-          (m) => m.VMCreateYAML,
-        ),
-      required: FLAG_KUBEVIRT,
-    },
-  },
-  {
-    type: 'Page/Route',
-    properties: {
-      exact: true,
-      path: ['/k8s/ns/:ns/virtualization/~new-wizard'],
-      loader: () =>
-        import(
-          './components/create-vm-wizard' /* webpackChunkName: "kubevirt-create-vm-wizard" */
-        ).then((m) => m.CreateVMWizardPage),
-      required: FLAG_KUBEVIRT,
-    },
-  },
-  {
-    type: 'Page/Route',
-    properties: {
-      path: '/k8s/ns/:ns/virtualmachines/:name',
-      loader: () =>
-        import('./components/vms/vm-details-page' /* webpackChunkName: "kubevirt" */).then(
-          (m) => m.VirtualMachinesDetailsPage,
-        ),
-    },
-  },
-  {
-    type: 'Page/Route',
-    properties: {
-      path: '/k8s/ns/:ns/virtualmachineinstances/:name',
-      loader: () =>
-        import('./components/vms/vmi-details-page' /* webpackChunkName: "kubevirt" */).then(
-          (m) => m.VirtualMachinesInstanceDetailsPage,
-        ),
-    },
-  },
-  {
-    type: 'Page/Route',
-    properties: {
-      path: ['/k8s/ns/:ns/virtualization', '/k8s/all-namespaces/virtualization'],
-      loader: () =>
-        import('./components/vms/virtualization' /* webpackChunkName: "kubevirt" */).then(
-          (m) => m.VirtualizationPage,
-        ),
-      required: FLAG_KUBEVIRT,
-    },
-  },
-  {
-    type: 'Page/Route',
-    properties: {
-      exact: true,
-      path: ['/k8s/ns/:ns/virtualmachines', '/k8s/all-namespaces/virtualmachines'],
-      loader: () =>
-        import('./components/vms/virtualization' /* webpackChunkName: "kubevirt" */).then(
-          (m) => m.RedirectToVirtualizationPage,
-        ),
-      required: FLAG_KUBEVIRT,
-    },
-  },
-  {
-    type: 'Page/Route',
-    properties: {
-      exact: true,
-      path: ['/k8s/ns/:ns/vmtemplates', '/k8s/all-namespaces/vmtemplates'],
-      loader: () =>
-        import('./components/vms/virtualization' /* webpackChunkName: "kubevirt" */).then(
-          (m) => m.RedirectToVirtualizationTemplatePage,
-        ),
-      required: FLAG_KUBEVIRT,
-    },
-  },
-  {
-    type: 'Page/Route',
-    properties: {
-      path: '/k8s/ns/:ns/vmtemplates/:name',
-      loader: () =>
-        import(
-          './components/vm-templates/vm-template-details-page' /* webpackChunkName: "kubevirt" */
-        ).then((m) => m.VMTemplateDetailsPage),
-      required: FLAG_KUBEVIRT,
-    },
-  },
-  {
-    type: 'Page/Route',
-    properties: {
-      exact: true,
-      path: ['/k8s/ns/:ns/vmtemplates', '/k8s/all-namespaces/vmtemplates'],
-      loader: () =>
-        import('./components/vm-templates/vm-template' /* webpackChunkName: "kubevirt" */).then(
-          (m) => m.VirtualMachineTemplatesPage,
-        ),
-      required: FLAG_KUBEVIRT,
-    },
-  },
+  // {
+  //   type: 'Page/Route',
+  //   properties: {
+  //     exact: true,
+  //     path: ['/k8s/ns/:ns/virtualization/~new'],
+  //     loader: () =>
+  //       import('./components/vms/vm-create-yaml' /* webpackChunkName: "kubevirt" */).then(
+  //         (m) => m.VMCreateYAML,
+  //       ),
+  //     required: FLAG_KUBEVIRT,
+  //   },
+  // },
+  // {
+  //   type: 'Page/Route',
+  //   properties: {
+  //     exact: true,
+  //     path: ['/k8s/ns/:ns/virtualization/~new-wizard'],
+  //     loader: () =>
+  //       import(
+  //         './components/create-vm-wizard' /* webpackChunkName: "kubevirt-create-vm-wizard" */
+  //       ).then((m) => m.CreateVMWizardPage),
+  //     required: FLAG_KUBEVIRT,
+  //   },
+  // },
+  // {
+  //   type: 'Page/Route',
+  //   properties: {
+  //     path: '/k8s/ns/:ns/virtualmachines/:name',
+  //     loader: () =>
+  //       import('./components/vms/vm-details-page' /* webpackChunkName: "kubevirt" */).then(
+  //         (m) => m.VirtualMachinesDetailsPage,
+  //       ),
+  //   },
+  // },
+  // {
+  //   type: 'Page/Route',
+  //   properties: {
+  //     path: '/k8s/ns/:ns/virtualmachineinstances/:name',
+  //     loader: () =>
+  //       import('./components/vms/vmi-details-page' /* webpackChunkName: "kubevirt" */).then(
+  //         (m) => m.VirtualMachinesInstanceDetailsPage,
+  //       ),
+  //   },
+  // },
+  // {
+  //   type: 'Page/Route',
+  //   properties: {
+  //     path: ['/k8s/ns/:ns/virtualization', '/k8s/all-namespaces/virtualization'],
+  //     loader: () =>
+  //       import('./components/vms/virtualization' /* webpackChunkName: "kubevirt" */).then(
+  //         (m) => m.VirtualizationPage,
+  //       ),
+  //     required: FLAG_KUBEVIRT,
+  //   },
+  // },
+  // {
+  //   type: 'Page/Route',
+  //   properties: {
+  //     exact: true,
+  //     path: ['/k8s/ns/:ns/virtualmachines', '/k8s/all-namespaces/virtualmachines'],
+  //     loader: () =>
+  //       import('./components/vms/virtualization' /* webpackChunkName: "kubevirt" */).then(
+  //         (m) => m.RedirectToVirtualizationPage,
+  //       ),
+  //     required: FLAG_KUBEVIRT,
+  //   },
+  // },
+  // {
+  //   type: 'Page/Route',
+  //   properties: {
+  //     exact: true,
+  //     path: ['/k8s/ns/:ns/vmtemplates', '/k8s/all-namespaces/vmtemplates'],
+  //     loader: () =>
+  //       import('./components/vms/virtualization' /* webpackChunkName: "kubevirt" */).then(
+  //         (m) => m.RedirectToVirtualizationTemplatePage,
+  //       ),
+  //     required: FLAG_KUBEVIRT,
+  //   },
+  // },
+  // {
+  //   type: 'Page/Route',
+  //   properties: {
+  //     path: '/k8s/ns/:ns/vmtemplates/:name',
+  //     loader: () =>
+  //       import(
+  //         './components/vm-templates/vm-template-details-page' /* webpackChunkName: "kubevirt" */
+  //       ).then((m) => m.VMTemplateDetailsPage),
+  //     required: FLAG_KUBEVIRT,
+  //   },
+  // },
+  // {
+  //   type: 'Page/Route',
+  //   properties: {
+  //     exact: true,
+  //     path: ['/k8s/ns/:ns/vmtemplates', '/k8s/all-namespaces/vmtemplates'],
+  //     loader: () =>
+  //       import('./components/vm-templates/vm-template' /* webpackChunkName: "kubevirt" */).then(
+  //         (m) => m.VirtualMachineTemplatesPage,
+  //       ),
+  //     required: FLAG_KUBEVIRT,
+  //   },
+  // },
   {
     type: 'Dashboards/Overview/Health/URL',
     properties: {

--- a/frontend/public/components/hypercloud/virtual-machine-instance.tsx
+++ b/frontend/public/components/hypercloud/virtual-machine-instance.tsx
@@ -80,7 +80,7 @@ const VirtualMachineInstanceDetails: React.FC<VirtualMachineInstanceDetailsProps
 const { details, editYaml } = navFactory;
 export const VirtualMachineInstances: React.FC = props => <Table {...props} aria-label="Virtual Machine Instances" Header={VirtualMachineInstanceTableHeader} Row={VirtualMachineInstanceTableRow} virtualize />;
 
-export const VirtualMachineInstancesPage: React.FC<VirtualMachineInstancesPageProps> = props => <ListPage canCreate={true} ListComponent={VirtualMachineInstances} kind={kind} {...props} />;
+export const VirtualMachineInstancesPage: React.FC<VirtualMachineInstancesPageProps> = props => <ListPage canCreate={false} ListComponent={VirtualMachineInstances} kind={kind} {...props} />;
 
 export const VirtualMachineInstancesDetailsPage: React.FC<VirtualMachineInstancesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(VirtualMachineInstanceDetails)), editYaml()]} />;
 


### PR DESCRIPTION
#### What:
- kubevirt-plugin 에 있는 라우팅 규칙 삭제
- vmi 생성 버튼 삭제

#### Why:
- kubevirt-plugin에 있는 라우팅 규칙으로 인해 kubevirt-plugin의 화면이 나옴
- vmi(Virtual Machine Instance)는 생성할 수 있는 리소스가 아님. vm을 실행/수정하면 생김

#### How:
- 불필요한 부분 삭제 혹은 주석